### PR TITLE
feat: set default shell to bash

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,6 +19,7 @@
         "ICS.japanese-proofreading"
       ],
       "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash",
         "latex-workshop.latex.tools": [
           {
             "name": "latexmk",


### PR DESCRIPTION
## やったこと

- VSCode デフォルトシェルを bash にした。

## 検証

手元でVSCode統合ターミナルを起動した時に bash が起動することを確認した。

<img width="1136" height="787" alt="image" src="https://github.com/user-attachments/assets/81ac3344-477c-4371-8211-0b0f20667c48" />
